### PR TITLE
Avoid including workspace dependencies that reference itself

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ const run = async ({ mode }: { mode: 'check' | 'write' }) => {
         ...tsConfig,
         references: info.workspaceDependencies
           .filter(isNotUndefined)
-          .filter(v => compositePackages.has(v))
+          .filter(v => compositePackages.has(v) && v !== info.location)
           .map((v) => path.relative(info.location, v))
           .map((v) => ({ path: v })),
       }


### PR DESCRIPTION
It appears that some workspaces report dependencies that reference itself, even when there might not actually be a build circular dependency present. This generates circular dependencies via the generated tsconfigs that include references to itself, which results in `tsc` build errors. This PR aims at preventing workspace dependencies from being included that are a reference to itself.